### PR TITLE
feat: add resolve_endpoint_auth() for decrypted endpoint credentials

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -249,6 +249,9 @@ Update an endpoint.
 **delete_endpoint(endpoint_id)**
 Delete an endpoint.
 
+**resolve_endpoint_auth(endpoint_id)**
+Resolve an endpoint's real, decrypted credentials. Unlike get_endpoint(), whose auth fields are masked (`*******`), this returns the decrypted Authorization header (Basic decrypted / OAuth2 token exchanged) plus, for Basic auth, the real username/password. Returns a dict: `{authType, authHeader, fetchCsrf, basic}` (`basic` is `null` for non-Basic auth).
+
 ### Endpoint Folders
 
 **get_endpoint_folders()**

--- a/src/datamaker/main.py
+++ b/src/datamaker/main.py
@@ -353,6 +353,11 @@ class DataMaker:
         """Delete an endpoint."""
         return self._endpoints.delete_endpoint(endpoint_id)
 
+    def resolve_endpoint_auth(self, endpoint_id: str):
+        """Resolve an endpoint's real, decrypted credentials (Authorization
+        header + Basic username/password). See EndpointsClient for details."""
+        return self._endpoints.resolve_endpoint_auth(endpoint_id)
+
     # =================== TEMPLATE FOLDER METHODS ===================
     def get_template_folders(self):
         """Get all template folders."""

--- a/src/datamaker/routes/custom_types.py
+++ b/src/datamaker/routes/custom_types.py
@@ -84,3 +84,17 @@ class EndpointsClient(BaseClient):
         """Delete an endpoint."""
         response = self._make_request("DELETE", f"/endpoints/{endpoint_id}")
         return response.json()
+
+    def resolve_endpoint_auth(self, endpoint_id: str) -> Dict:
+        """Resolve an endpoint's real, usable credentials.
+
+        Unlike get_endpoint(), whose auth fields are masked (`*******`), this
+        returns the decrypted Authorization header (Basic decrypted / OAuth2
+        token exchanged) plus, for Basic auth, the real username/password.
+
+        Returns a dict: {authType, authHeader, fetchCsrf, basic}.
+        """
+        response = self._make_request(
+            "POST", "/endpoints/auth-resolve", json={"endpointId": endpoint_id}
+        )
+        return response.json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,6 +12,7 @@ from src.datamaker.routes.projects import ProjectsClient
 from src.datamaker.routes.users import UsersClient
 from src.datamaker.routes.teams import TeamsClient, TeamMembersClient
 from src.datamaker.routes.sets import SetsClient
+from src.datamaker.routes.custom_types import EndpointsClient
 from src.datamaker.error import DataMakerError
 
 
@@ -664,3 +665,28 @@ class TestSetsClient:
         }
         mock_make_request.assert_called_once_with("POST", "/sets", json=expected_data)
         assert result["rowCount"] == 1
+
+
+class TestEndpointsClient:
+    """Test cases for the EndpointsClient class."""
+
+    @patch("src.datamaker.routes.base.BaseClient._make_request")
+    def test_resolve_endpoint_auth(self, mock_make_request, api_key):
+        """Test resolving an endpoint's real, decrypted credentials."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "authType": "Basic",
+            "authHeader": "Basic dXNlcjpwYXNz",
+            "fetchCsrf": None,
+            "basic": {"username": "user", "password": "pass"},
+        }
+        mock_make_request.return_value = mock_response
+
+        client = EndpointsClient(api_key=api_key)
+        result = client.resolve_endpoint_auth("endpoint-1")
+
+        mock_make_request.assert_called_once_with(
+            "POST", "/endpoints/auth-resolve", json={"endpointId": "endpoint-1"}
+        )
+        assert result["authType"] == "Basic"
+        assert result["basic"]["username"] == "user"


### PR DESCRIPTION
## Summary

Closes #18.

Adds a first-class `resolve_endpoint_auth(endpoint_id)` method to the SDK so callers can obtain an endpoint's **real, decrypted credentials** without reaching into private internals (`dm._endpoints._make_request(...)`).

The DataMaker API masks credentials (`*******`) on every endpoint *read* route, so `get_endpoint()` / `get_endpoints()` return masked auth. This new method calls `POST /endpoints/auth-resolve` (decryption stays server-side) and returns the real Authorization header (Basic decrypted / OAuth2 token exchanged) plus, for Basic auth, the decrypted username/password.

## Changes

- **`src/datamaker/routes/custom_types.py`** — `EndpointsClient.resolve_endpoint_auth()`
- **`src/datamaker/main.py`** — `DataMaker.resolve_endpoint_auth()` facade method
- **`tests/test_routes.py`** — `TestEndpointsClient` unit test asserting the request shape and response passthrough
- **`llms.txt`** — documented under the Endpoints section

## Usage

```python
resolved = dm.resolve_endpoint_auth(endpoint_id)
# {"authType": "Basic", "authHeader": "Basic ...", "fetchCsrf": ..., "basic": {"username": ..., "password": ...}}
```

Response shape mirrors the API route: `{authType, authHeader, fetchCsrf, basic}` (`basic` is `null` for non-Basic auth). The endpoint is gated by the same access check as the rest of the API (403 if the caller lacks access).

## Tests

`pytest tests/test_routes.py tests/test_main.py -m "not integration"` → 62 passed.

## Follow-up

Once merged, bump the pinned commit in `datamaker-runner` (`pyproject.toml` + `uv.lock`) as noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)