### PR TITLE
fix(packaging): drop bogus tool/ruff runtime deps, declare build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "datamaker-py"
 version = "0.7.0"
@@ -7,6 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
     "python-dotenv>=1.0.1",
     "requests>=2.32.3",
-    "ruff>=0.14.0",
-    "tool>=0.8.0",
 ]
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## Problem

`tool>=0.8.0` and `ruff>=0.14.0` are declared as **runtime** dependencies but are **not imported anywhere** in the SDK:
- `ruff` is a linter (dev-only at most).
- `tool` is unrelated **2011 abandonware** (GPL3; pulls `argh`/`pydispatcher`/`pyyaml`; sdist-only, no wheels).

The DataMaker desktop app builds its Python runner venv **offline on Windows** (`uv sync --frozen --offline --no-index --find-links wheelhouse`). These extra source-only deps must be built on the user's machine with no network. That build fails / the wheelhouse can't satisfy it, `uv sync` aborts, the runner venv is never created, and **scenarios silently never run on Windows**. macOS installs online and tolerated it.

## Fix

- Remove `tool` and `ruff` from runtime `dependencies` (neither is imported).
- Add an explicit setuptools `[build-system]` and `[tool.setuptools.packages.find] where = ["src"]` so the wheel build no longer depends on the frontend's implicit backend / src-layout autodiscovery.

## Verification

`uv build --wheel` produces a clean wheel:
- `Requires-Dist`: only `python-dotenv>=1.0.1` and `requests>=2.32.3`
- `datamaker/` package correctly included (`datamaker/__init__.py`, `main.py`, `routes/*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)