### PR TITLE
ci: build + attach wheel/sdist to GitHub release (drop PyPI publishing)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,6 +19,10 @@ jobs:
   release-build:
     runs-on: ubuntu-latest
 
+    # Needed so we can attach the built wheel + sdist to the GitHub release.
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -29,11 +33,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-      
+
       - name: Install dependencies
         run: |
           uv sync --all-extras --dev
-          
+
       - name: Build release distributions
         run: |
           uv build
@@ -44,8 +48,25 @@ jobs:
           name: release-dists
           path: dist/
 
+      # Attach the wheel (and sdist) to the GitHub release so consumers can pin a
+      # direct `.whl` URL, e.g.
+      #   datamaker-py @ https://github.com/automators-com/datamaker-py/releases/download/<tag>/datamaker_py-<ver>-py3-none-any.whl
+      # Because the URL ends in `.whl`, uv/pip install it as a wheel with NO build
+      # step (the DataMaker desktop runner needs this to provision its venv fully
+      # offline). The repo is public, so the asset URL needs no auth.
+      - name: Attach distributions to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" dist/*.whl dist/*.tar.gz --clobber
+
   pypi-publish:
     runs-on: ubuntu-latest
+    # Opt-in: PyPI trusted publishing must be configured (project registered on
+    # PyPI with this repo's `pypi` environment as a trusted publisher) before
+    # this can succeed. Until then it's disabled so releases don't fail on it.
+    # Enable by setting the repo variable PUBLISH_TO_PYPI=true.
+    if: ${{ vars.PUBLISH_TO_PYPI == 'true' }}
     needs:
       - release-build
     permissions:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,10 +1,5 @@
-# This workflow will upload a Python Package to PyPI when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# On a published GitHub release, build the package and attach the wheel + sdist
+# as release assets so consumers can pin a direct `.whl` URL (no PyPI involved).
 
 name: Upload Python Package
 
@@ -34,19 +29,9 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install dependencies
-        run: |
-          uv sync --all-extras --dev
-
       - name: Build release distributions
         run: |
           uv build
-
-      - name: Upload distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
 
       # Attach the wheel (and sdist) to the GitHub release so consumers can pin a
       # direct `.whl` URL, e.g.
@@ -59,39 +44,3 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${{ github.event.release.tag_name }}" dist/*.whl dist/*.tar.gz --clobber
-
-  pypi-publish:
-    runs-on: ubuntu-latest
-    # Opt-in: PyPI trusted publishing must be configured (project registered on
-    # PyPI with this repo's `pypi` environment as a trusted publisher) before
-    # this can succeed. Until then it's disabled so releases don't fail on it.
-    # Enable by setting the repo variable PUBLISH_TO_PYPI=true.
-    if: ${{ vars.PUBLISH_TO_PYPI == 'true' }}
-    needs:
-      - release-build
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-
-    # Dedicated environments with protections for publishing are strongly recommended.
-    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
-    environment:
-      name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-      url: https://pypi.org/p/datamaker-py
-      #
-      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
-      # ALTERNATIVE: exactly, uncomment the following line instead:
-      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
-
-    steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
-
-      - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/


### PR DESCRIPTION
## Why

The DataMaker desktop runner pins `datamaker-py` by **source-archive URL** (`/archive/<sha>.tar.gz`), an **sdist** that uv/pip must *build* at install time. That build is what blocks the desktop app from provisioning its Python venv fully offline.

## What

- On a published release, `uv build` and attach the **wheel + sdist** as GitHub release assets. Consumers pin a direct `.whl` URL:
  ```
  datamaker-py @ https://github.com/automators-com/datamaker-py/releases/download/<tag>/datamaker_py-<ver>-py3-none-any.whl
  ```
  URL ends in `.whl` → installs as a wheel, **no build step**. Repo is public → no auth.
- **Removed** the PyPI trusted-publishing job entirely (project isn't on PyPI; standardizing on GitHub release assets).

## Next

1. Merge → cut release `v0.7.0` (wheel attaches automatically).
2. Re-pin the runner to the release `.whl` URL + regenerate the lock → runtime does zero building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)